### PR TITLE
Update README and related files with new project location after move to Commissure

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ The red box (aka red screen of death) renders an error in this “pretty” form
 
 ## Usage
 Catch an error and give it to `redbox-react`. Works with
-* [react-transform-catch-errors](https://github.com/gaearon/react-transform-catch-errors) ([see example](https://github.com/KeywordBrain/redbox-react/tree/master/examples/react-transform-catch-errors) or [react-transform-boilerplate](https://github.com/gaearon/react-transform-boilerplate/))
-* [react-hot-loader](https://github.com/gaearon/react-hot-loader) (⚠️ based on 3.0.0-beta.2! This depends on ErrorBoundaries which will likely not land in react! You should probably not use this before 3.0.0 comes out; see [example](https://github.com/KeywordBrain/redbox-react/tree/master/examples/react-hot-loader))
+* [react-transform-catch-errors](https://github.com/gaearon/react-transform-catch-errors) ([see example](https://github.com/commissure/redbox-react/tree/master/examples/react-transform-catch-errors) or [react-transform-boilerplate](https://github.com/gaearon/react-transform-boilerplate/))
+* [react-hot-loader](https://github.com/gaearon/react-hot-loader) (⚠️ based on 3.0.0-beta.2! This depends on ErrorBoundaries which will likely not land in react! You should probably not use this before 3.0.0 comes out; see [example](https://github.com/commissure/redbox-react/tree/master/examples/react-hot-loader))
 
 or manually:
 
@@ -44,10 +44,11 @@ if (__DEV__) {
 ```
 
 ## What is this good for?
+
 An error that's only in the console is only half the fun. Now you can use all the wasted space where your app would be if it didn’t crash to display the error that made it crash. You should use this in development only.
 
 ## Will this catch errors for me?
-No. As you can see above, this is only a UI component for rendering errors and their stack traces. It's works great with other solutions, that automate the error catching for you, see the [examples](https://github.com/KeywordBrain/redbox-react/tree/master/examples).
+No. As you can see above, this is only a UI component for rendering errors and their stack traces. It's works great with other solutions, that automate the error catching for you, see the [examples](https://github.com/commissure/redbox-react/tree/master/examples).
 
 ## Optional props
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # redbox-react
 
-[![Build Status](https://travis-ci.org/KeywordBrain/redbox-react.svg?branch=master)](https://travis-ci.org/KeywordBrain/redbox-react)
+[![Build Status](https://travis-ci.org/commissure/redbox-react.svg?branch=master)](https://travis-ci.org/commissure/redbox-react)
 [![semantic-release](https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg)](https://github.com/semantic-release/semantic-release)
 
 The red box (aka red screen of death) renders an error in this “pretty” format:

--- a/README.md
+++ b/README.md
@@ -8,9 +8,23 @@ The red box (aka red screen of death) renders an error in this “pretty” form
 <img src="http://i.imgur.com/9Jhlibk.png" alt="red screen of death" width="700" />
 
 ## Usage
-Catch an error and give it to `redbox-react`. Works with
-* [react-transform-catch-errors](https://github.com/gaearon/react-transform-catch-errors) ([see example](https://github.com/commissure/redbox-react/tree/master/examples/react-transform-catch-errors) or [react-transform-boilerplate](https://github.com/gaearon/react-transform-boilerplate/))
-* [react-hot-loader](https://github.com/gaearon/react-hot-loader) (⚠️ based on 3.0.0-beta.2! This depends on ErrorBoundaries which will likely not land in react! You should probably not use this before 3.0.0 comes out; see [example](https://github.com/commissure/redbox-react/tree/master/examples/react-hot-loader))
+
+Catch an error and give it to `redbox-react`. Works great with
+
+- [react-transform-catch-errors]
+  - [Example][react-transform-example]
+  - [react-transform-boilerplate]
+- [react-hot-loader]
+  - :warning: ️ based on `3.0.0-beta.2`! This depends on `ErrorBoundaries` which
+    will likely not land in react! You should probably not use this
+    before 3.0.0 comes out.
+  - [Example][react-hot-loader-example]
+
+[react-transform-catch-errors]: https://github.com/gaearon/react-transform-catch-errors
+[react-transform-example]: https://github.com/commissure/redbox-react/tree/master/examples/react-transform-catch-errors
+[react-transform-boilerplate]: https://github.com/gaearon/react-transform-boilerplate/
+[react-hot-loader]: https://github.com/gaearon/react-hot-loader
+[react-hot-loader-example]: https://github.com/commissure/redbox-react/tree/master/examples/react-hot-loader
 
 or manually:
 
@@ -43,32 +57,53 @@ if (__DEV__) {
 }
 ```
 
-## What is this good for?
+## What Is This Good For?
 
-An error that's only in the console is only half the fun. Now you can use all the wasted space where your app would be if it didn’t crash to display the error that made it crash. You should use this in development only.
+An error that's only in the console is only half the fun. Now you can
+use all the wasted space where your app would be if it didn’t crash to
+display the error that made it crash.
+
+**Please use this in development only.**
 
 ## Will this catch errors for me?
-No. As you can see above, this is only a UI component for rendering errors and their stack traces. It's works great with other solutions, that automate the error catching for you, see the [examples](https://github.com/commissure/redbox-react/tree/master/examples).
+No. This is only a UI component for rendering errors and their stack
+traces. It is intended to be used with with other existing solutions
+that automate the error catching for you. See the list at the top of
+this document or take a look at the [examples].
 
-## Optional props
+  [examples]: https://github.com/commissure/redbox-react/tree/master/examples
 
-`editorScheme` `[?string]` If a filename in the stack trace is local, the component can create the
-link to open your editor using this scheme eg: `subl` to create `subl://open?url=file:///filename`.
+## Optional Props
 
-`useLines` `[boolean=true]` Line numbers in the stack trace may be unreliable depending on the
+The `RedBox` component takes a couple of props that you can use to
+customize its behaviour:
+
+### `editorScheme` `[?string]`
+If a filename in the stack trace is local, the component can create the
+link to open your editor using this scheme eg: `subl` to create
+`subl://open?url=file:///filename`.
+
+### `useLines` `[boolean=true]`
+Line numbers in the stack trace may be unreliable depending on the
 type of sourcemaps. You can choose to not display them with this flag.
 
-`useColumns` `[boolean=true]` Column numbers in the stack trace may be unreliable depending on the
+### `useColumns` `[boolean=true]`
+Column numbers in the stack trace may be unreliable depending on the
 type of sourcemaps. You can choose to not display them with this flag.
 
-`style` `[?object]` Allows you to override the styles used when rendering the various parts of the
+### `style` `[?object]`
+Allows you to override the styles used when rendering the various parts of the
 component. It will be shallow-merged with the [default styles](./src/style.js).
 
-If using [react-transform-catch-errors](https://github.com/gaearon/react-transform-catch-errors#installation) you can add these options to your `.babelrc` through the [`imports` property](https://github.com/gaearon/react-transform-catch-errors#installation).
+If you’re using [react-transform-catch-errors] you can add these
+options to your `.babelrc` through the [`imports` property][imports].
 
-## Sourcemaps with Webpack
+  [imports]: https://github.com/gaearon/react-transform-catch-errors#installation
 
-If using [Webpack](https://webpack.github.io) you can get accurate filenames in the stacktrace by
-setting the `output.devtoolModuleFilenameTemplate` settings to `/[absolute-resource-path]`.
+## Sourcemaps With Webpack
 
-It's recommended to set `devtool` setting to `'eval'`.
+If you’re using [Webpack](https://webpack.github.io) you can get
+accurate filenames in the stacktrace by setting the
+`output.devtoolModuleFilenameTemplate` settings to `/[absolute-resource-path]`.
+
+It's recommended to set the `devtool` setting to `'eval'`.

--- a/package.json
+++ b/package.json
@@ -19,14 +19,14 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/KeywordBrain/redbox-react.git"
+    "url": "git+https://github.com/commissure/redbox-react.git"
   },
-  "author": "David Pfahler <david@keywordbrain.com>",
+  "author": "David Pfahler",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/KeywordBrain/redbox-react/issues"
+    "url": "https://github.com/commissure/redbox-react/issues"
   },
-  "homepage": "https://github.com/KeywordBrain/redbox-react",
+  "homepage": "https://github.com/commissure/redbox-react",
   "keywords": [
     "redbox",
     "rsod",


### PR DESCRIPTION
This PR updates links to examples and author information in the `README` and `package.json`.

The final touches for #69 so to say.