### PR TITLE
Revert "Move react-dom from deps to peerDeps"

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,11 +51,11 @@
     "webpack": "^1.13.1"
   },
   "peerDependencies": {
-    "react": "^0.14.0 || ^15.0.0",
-    "react-dom": "^0.14.0 || ^15.0.0"
+    "react": "^0.14.0 || ^15.0.0"
   },
   "dependencies": {
     "error-stack-parser": "^1.3.6",
-    "object-assign": "^4.0.1"
+    "object-assign": "^4.0.1",
+    "react-dom": "^0.14.0 || ^15.0.0"
   }
 }


### PR DESCRIPTION
Reverts commissure/redbox-react#74

Reverting because I forgot the semantic-release commit "notation" and it doesn't reject invalid commits. I'll revert and try again by reverting this PR 😢 .