### PR TITLE
fix(style): ensure redbox always is in the foreground by setting defa…

### DIFF
--- a/src/style.js
+++ b/src/style.js
@@ -11,7 +11,7 @@ export default {
     width: '100%',
     background: 'rgb(204, 0, 0)',
     color: 'white',
-    zIndex: 9999,
+    zIndex: 2147483647,
     textAlign: 'left',
     fontSize: '16px',
     lineHeight: 1.2,


### PR DESCRIPTION
In reference to issue [78](https://github.com/commissure/redbox-react/issues/78), this minor fix ensures that RedBox always is in the foreground, by setting default z-index of the RedBox to the maximum value accepted by [most browsers](https://stackoverflow.com/questions/491052/minimum-and-maximum-value-of-z-index/25461690#25461690)