### PR TITLE
Changes the overflow  to auto for show scroll bars only if is needed

### DIFF
--- a/src/style.js
+++ b/src/style.js
@@ -15,7 +15,7 @@ export default {
     textAlign: 'left',
     fontSize: '16px',
     lineHeight: 1.2,
-    overflow: 'scroll'
+    overflow: 'auto'
   },
   message: {
     fontWeight: 'bold'


### PR DESCRIPTION
With `overflow: scroll;`

![image](https://cloud.githubusercontent.com/assets/5122156/22978954/cc209292-f37b-11e6-8d67-e18dee18b2f8.png)

With `overflow: auto;`

![image](https://cloud.githubusercontent.com/assets/5122156/22978993/f77e9718-f37b-11e6-8b06-b0727c52a8bf.png)
