### PR TITLE
fix(react): Migrate from React.PropTypes

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     "react-native"
   ],
   "devDependencies": {
-    "react": "^0.14.0 || ^15.0.0",
     "babel-cli": "^6.9.0",
     "babel-core": "^6.9.0",
     "babel-loader": "^6.2.4",
@@ -42,6 +41,8 @@
     "babel-preset-es2015": "^6.3.3",
     "babel-preset-react": "^6.5.0",
     "babel-preset-stage-0": "^6.3.13",
+    "prop-types": "^15.5.4",
+    "react": "^0.14.0 || ^15.0.0",
     "react-addons-test-utils": "^15.0.0",
     "react-dom": "^0.14.0 || ^15.0.0",
     "rimraf": "^2.5.2",

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
-import React, {Component, PropTypes} from 'react'
+import PropTypes from 'prop-types';
+import React, {Component} from 'react'
 import ReactDOM from 'react-dom'
 import style from './style.js'
 import ErrorStackParser from 'error-stack-parser'


### PR DESCRIPTION
With React 15.5.0, [`React.PropTypes` are now extracted to a separate package](https://facebook.github.io/react/blog/2017/04/07/react-v15.5.0.html#migrating-from-react.proptypes). 

They are still accessible via the main React object, but using them will log a deprecation warning to the console when in development mode.

![screen shot 2017-04-08 at 16 55 03](https://cloud.githubusercontent.com/assets/494699/24829942/3390e426-1c7c-11e7-8ee3-28720e13eb99.png)
