### PR TITLE
move prop-types to dependencies in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
     "babel-preset-es2015": "^6.3.3",
     "babel-preset-react": "^6.5.0",
     "babel-preset-stage-0": "^6.3.13",
-    "prop-types": "^15.5.4",
     "react": "^0.14.0 || ^15.0.0",
     "react-addons-test-utils": "^15.0.0",
     "react-dom": "^0.14.0 || ^15.0.0",
@@ -58,6 +57,7 @@
   },
   "dependencies": {
     "error-stack-parser": "^1.3.6",
-    "object-assign": "^4.0.1"
+    "object-assign": "^4.0.1",
+    "prop-types": "^15.5.4"
   }
 }


### PR DESCRIPTION
<img width="1295" alt="screen shot 2017-04-08 at 8 12 13 pm" src="https://cloud.githubusercontent.com/assets/2916773/24834413/fa15d50e-1c98-11e7-959d-00fb55a8abc6.png">

prop-types package failed to install. As soon as I installed prop-types the warning went away.  redbox-react has prop-types listed in their devDependencies, but not in dependencies, yet it is imported in src/index.js file which means it should be under "dependencies" in the package.json? The only other place might be peerDependencies, but unless you're stripping out PropTypes in the production release it will _need_ to be installed.

I mean, the react team is planning on supporting their own option, so you might, eventually, just be able to move that one into peerDependencies.

Let me know if this makes sense.