### PR TITLE
Support mixed eval & non-eval stack traces

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -61,10 +61,16 @@ export class RedBoxError extends Component {
     let fixedLines = [stackLines.shift()]
     // The rest needs to be fixed.
     for (let stackLine of stackLines) {
-      let [, atSomething, file, rowColumn] = stackLine.match(
+      const evalStackLine = stackLine.match(
         /(.+)\(eval at (.+) \(.+?\), .+(\:[0-9]+\:[0-9]+)\)/
       )
-      fixedLines.push(`${atSomething} (${file}${rowColumn})`)
+      if (evalStackLine) {
+        const [, atSomething, file, rowColumn] = evalStackLine
+        fixedLines.push(`${atSomething} (${file}${rowColumn})`)
+      } else {
+        // TODO: When stack frames of different types are detected, try to load the additional source maps
+        fixedLines.push(stackLine)
+      }
     }
     error.stack = fixedLines.join('\n')
     this.state = { error, mapped: true }


### PR DESCRIPTION
This builds on the change in https://github.com/commissure/redbox-react/pull/94 to support stack traces that contain both eval and non-eval lines. I suspect these mixed stack traces are coming from my vendor bundle having been built with `source-map`, while my application bundle is built with `cheap-module-eval-source-map`.

Example JSONified `stackLines` that is only supported after this change:
> [
>   "    at _default (eval at ./src/routes.js (http://localhost:3000/app.js?ef9dba4c6d4b1c818e5b:11663:1), <anonymous>:357:171)",
>   "    at new Root (eval at ./src/containers/Root.js (http://localhost:3000/app.js?ef9dba4c6d4b1c818e5b:8598:1), <anonymous>:27:94)",
>   "    at eval (eval at ./node_modules/react-proxy/modules/createClassProxy.js (http://localhost:3000/app.js?ef9dba4c6d4b1c818e5b:4180:1), <anonymous>:95:24)",
>   "    at instantiate (eval at ./node_modules/react-proxy/modules/createClassProxy.js (http://localhost:3000/app.js?ef9dba4c6d4b1c818e5b:4180:1), <anonymous>:103:9)",
>   "    at Root (eval at proxyClass (eval at ./node_modules/react-proxy/modules/createClassProxy.js (http://localhost:3000/app.js?ef9dba4c6d4b1c818e5b:4180:1)), <anonymous>:4:17)",
>   "    at eval (webpack:///./\~/react-dom/lib/ReactCompositeComponent.js?:306:16)",
>   "    at measureLifeCyclePerf (webpack:///./\~/react-dom/lib/ReactCompositeComponent.js?:75:12)",
>   "    at ReactCompositeComponentWrapper._constructComponentWithoutOwner (webpack:///./\~/react-dom/lib/ReactCompositeComponent.js?:305:14)",
>   "    at ReactCompositeComponentWrapper._constructComponent (webpack:///./\~/react-dom/lib/ReactCompositeComponent.js?:280:21)",
>   "    at ReactCompositeComponentWrapper.mountComponent (webpack:///./\~/react-dom/lib/ReactCompositeComponent.js?:188:21)"
> ]