### PR TITLE
Updates babel-plugin-rewire to version 1.0.0.

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "babel-cli": "^6.9.0",
     "babel-core": "^6.9.0",
     "babel-loader": "^6.2.4",
-    "babel-plugin-rewire": "^1.0.0-rc-3",
+    "babel-plugin-rewire": "1.0.0",
     "babel-plugin-transform-async-generator-functions": "^6.24.1",
     "babel-plugin-transform-class-properties": "^6.19.0",
     "babel-plugin-transform-do-expressions": "^6.22.0",


### PR DESCRIPTION
Updates to 1.0.0, but not to 1.1.0, until they address the problem that presents itself [here](https://github.com/naviapps/nw-react-boilerplate/issues/3) and [here](https://github.com/naviapps/nw-react-boilerplate/issues/4).